### PR TITLE
Фикс аттачметов

### DIFF
--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -71,6 +71,7 @@ Defined in conflicts.dm of the #defines folder.
 	var/bipod_deployed = FALSE //only used by bipod
 	var/current_rounds 	= 0 //How much it has.
 	var/max_rounds 		= 0 //How much ammo it can store
+	var/attach_applied = FALSE //Prevents it from getting picked up after being attached
 
 	var/attachment_action_type
 
@@ -86,10 +87,15 @@ Defined in conflicts.dm of the #defines folder.
 		else
 			. = ..()
 
-
+obj/item/attachable/attack_hand(var/mob/user as mob)
+	if(src.attach_applied == TRUE)
+		return
+	else
+		..()
 
 /obj/item/attachable/proc/Attach(obj/item/weapon/gun/G)
 	if(!istype(G)) return //Guns only
+	attach_applied = TRUE
 
 	/*
 	This does not check if the attachment can be removed.
@@ -155,6 +161,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/proc/Detach(obj/item/weapon/gun/G)
 	if(!istype(G)) return //Guns only
+	attach_applied = FALSE
 
 
 	if(flags_attach_features & ATTACH_ACTIVATION)


### PR DESCRIPTION
Порт https://github.com/ColonialMarines-Mirror/ColonialMarines-2018/pull/192
Если дропнуть аттачмент под себя и подобрать через альт клик после чего прикрутить к оружию, аттачмент остается в боковом меню и его можно подобрать