### PR TITLE
Фикс мгновенного открепления аттачей

### DIFF
--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -495,6 +495,8 @@ should be alright.
 	else //attaching as usual.
 		usr.visible_message("<span class='notice'>[usr] begins stripping the [A] from [src].</span>",
 		"<span class='notice'>You begin stripping the [A] from [src].</span>", null, 4)
+	if(!do_after(usr,detach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
+		return
 
 	if(A != rail && A != muzzle && A != under && A != stock)
 		return

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -342,7 +342,7 @@ should be alright.
 	else //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
 		attach_delay *= 2
 		user.visible_message("<span class='notice'>[user] begins fumbling about, trying to attach [attachment] to [src].</span>",
-		"<span class='notice'>You begin funmbling about, trying to attach [attachment] to [src].</span>", null, 4)
+		"<span class='notice'>You begin fumbling about, trying to attach [attachment] to [src].</span>", null, 4)
 	//user.visible_message("","<span class='notice'>Attach Delay = [attach_delay]. Attachment = [attachment]. Firearm Skill = [usr.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
 	if(do_after(user,attach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		if(attachment && attachment.loc)
@@ -505,7 +505,7 @@ should be alright.
 	else //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
 		detach_delay *= 2
 		usr.visible_message("<span class='notice'>[usr] begins fumbling about, trying to strip [A] from [src].</span>",
-		"<span class='notice'>You begin funmbling about, trying to strip [A] from [src].</span>", null, 4)
+		"<span class='notice'>You begin fumbling about, trying to strip [A] from [src].</span>", null, 4)
 	//usr.visible_message("","<span class='notice'>Detach Delay = [detach_delay]. Attachment = [A]. Firearm Skill = [usr.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
 	if(!do_after(usr,detach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		return

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -327,15 +327,23 @@ should be alright.
 		return
 
 	var/attach_delay = 30
-	if(attachment == "bayonet" && (!src.muzzle || src.muzzle == "bayonet")) //Attach  bayonet fast if no attachment to remove on the barrel, or you're replacing a bayo with another bayo
+	var/firearm_skill = user.mind.cm_skills.firearms
+	if(attachment.name == "bayonet" && (!src.muzzle || src.muzzle.name == "bayonet")) //Attach  bayonet fast if no attachment to remove on the barrel, or you're replacing a bayo with another bayo
 		attach_delay = 10
-	if(user.mind && user.mind.cm_skills && user.mind.cm_skills.firearms == 0) //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
+	if (user.mind && user.mind.cm_skills && firearm_skill)
+		if(attachment.name == "bayonet")
+			user.visible_message("<span class='notice'>[user] fixes [attachment]!.</span>",
+			"<span class='notice'>You fix [attachment]!</span>", null, 4)
+		else
+			user.visible_message("<span class='notice'>[user] begins attaching [attachment] to [src].</span>",
+			"<span class='notice'>You begin attaching [attachment] to [src].</span>", null, 4)
+		if(firearm_skill >= 2) //See if the attacher is super skilled/panzerelite born to defeat never retreat etc
+			attach_delay *= 0.5
+	else //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
 		attach_delay *= 2
-		user.visible_message("<span class='notice'>[user] begins fumbling about, trying to attach the [attachment] to [src].</span>",
-		"<span class='notice'>You begin funmbling about, trying to attach the [attachment] to [src].</span>", null, 4)
-	else //attaching as usual.
-		user.visible_message("<span class='notice'>[user] begins attaching the [attachment] to [src].</span>",
-		"<span class='notice'>You begin attaching the [attachment] to [src].</span>", null, 4)
+		user.visible_message("<span class='notice'>[user] begins fumbling about, trying to attach [attachment] to [src].</span>",
+		"<span class='notice'>You begin funmbling about, trying to attach [attachment] to [src].</span>", null, 4)
+	//user.visible_message("","<span class='notice'>Attach Delay = [attach_delay]. Attachment = [attachment]. Firearm Skill = [usr.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
 	if(do_after(user,attach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		if(attachment && attachment.loc)
 			user.visible_message("<span class='notice'>[user] attaches [attachment] to [src].</span>",
@@ -486,15 +494,19 @@ should be alright.
 		return
 
 	var/detach_delay = 30
-	if(A == "bayonet") //Detach the bayonet fast
+	var/firearm_skill = usr.mind.cm_skills.firearms
+	if(A.name == "bayonet") //Detach the bayonet fast
 		detach_delay = 10
-	if(usr.mind && usr.mind.cm_skills && usr.mind.cm_skills.firearms == 0) //If the user has no training, detaching takes twice as long and they fumble about, looking like a retard.
+	if (usr.mind && usr.mind.cm_skills && firearm_skill)
+		usr.visible_message("<span class='notice'>[usr] begins stripping [A] from [src].</span>",
+		"<span class='notice'>You begin stripping [A] from [src].</span>", null, 4)
+		if(firearm_skill >= 2) //See if the attacher is super skilled/panzerelite born to defeat never retreat etc
+			detach_delay *= 0.5
+	else //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
 		detach_delay *= 2
-		usr.visible_message("<span class='notice'>[usr] begins fumbling about, trying to strip the [A] from [src].</span>",
-		"<span class='notice'>You begin fumbling about, trying to strip the [A] from [src].</span>", null, 4)
-	else //attaching as usual.
-		usr.visible_message("<span class='notice'>[usr] begins stripping the [A] from [src].</span>",
-		"<span class='notice'>You begin stripping the [A] from [src].</span>", null, 4)
+		usr.visible_message("<span class='notice'>[usr] begins fumbling about, trying to strip [A] from [src].</span>",
+		"<span class='notice'>You begin funmbling about, trying to strip [A] from [src].</span>", null, 4)
+	//usr.visible_message("","<span class='notice'>Detach Delay = [detach_delay]. Attachment = [A]. Firearm Skill = [usr.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
 	if(!do_after(usr,detach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		return
 


### PR DESCRIPTION
Проебался в #20 удалив нужную линию.
Нужно еще будет пофиксить крепление штыка в одну секунду либо забить на него.