### PR TITLE
Убирание вайтлиста для синтов

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -128,16 +128,13 @@
 
 /datum/skills/synthetic
 	name = "Synthetic"
-	cqc = SKILL_CQC_MASTER
 	engineer = SKILL_ENGINEER_MT
 	construction = SKILL_CONSTRUCTION_MASTER
 	firearms = SKILL_FIREARMS_TRAINED
 	smartgun = SKILL_SMART_TRAINED
 	spec_weapons = SKILL_SPEC_TRAINED
-	leadership = SKILL_LEAD_EXPERT
 	medical = SKILL_MEDICAL_CMO
 	surgery = SKILL_SURGERY_EXPERT
-	melee_weapons = SKILL_MELEE_SUPER
 	pilot = SKILL_PILOT_TRAINED
 	pistols = SKILL_PISTOLS_TRAINED
 	smgs = SKILL_SMGS_TRAINED
@@ -150,7 +147,6 @@
 
 /datum/skills/early_synthetic
 	name = "Early Synthetic"
-	cqc = SKILL_MELEE_TRAINED
 	engineer = SKILL_ENGINEER_MT
 	construction = SKILL_CONSTRUCTION_MASTER
 	firearms = SKILL_FIREARMS_TRAINED

--- a/code/game/jobs/job/civilians.dm
+++ b/code/game/jobs/job/civilians.dm
@@ -214,7 +214,7 @@ Best to let the mercs do the killing and the dying, but remind them who pays the
 	supervisors = "the acting commander"
 	selection_color = "#aaee55"
 	idtype = /obj/item/card/id/gold
-	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_MODE|ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED
+	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_MODE|ROLE_ADMIN_NOTIFY
 	flags_whitelist = WHITELIST_SYNTHETIC
 	skills_type = /datum/skills/synthetic
 
@@ -256,7 +256,7 @@ Best to let the mercs do the killing and the dying, but remind them who pays the
 		H.name = H.get_visible_name()
 
 	generate_entry_message()
-		. = {"You are a Synthetic! You are held to a higher standard and are required to obey not only the Server Rules but Marine Law and Synthetic Rules. Failure to do so may result in your White-list Removal.
+		. = {"You are a Synthetic!
 Your primary job is to support and assist all USCM Departments and Personnel on-board.
 In addition, being a Synthetic gives you knowledge in every field and specialization possible on-board the ship.
 As a Synthetic you answer to the acting commander. Special circumstances may change this!"}

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -276,9 +276,9 @@ datum/preferences
 		dat += "<b>Mask style:</b> <a href='?_src_=prefs;preference=pred_mask_type;task=input'>([predator_mask_type])</a><br>"
 		dat += "<b>Armor style:</b> <a href='?_src_=prefs;preference=pred_armor_type;task=input'>([predator_armor_type])</a><br>"
 		dat += "<b>Greave style:</b> <a href='?_src_=prefs;preference=pred_boot_type;task=input'>([predator_boot_type])</a><br><br>"
-	if(RoleAuthority.roles_whitelist[user.ckey] & WHITELIST_SYNTHETIC)
-		dat += "<br><b>Synthetic name:</b> <a href='?_src_=prefs;preference=synth_name;task=input'>[synthetic_name]</a><br>"
-		dat += "<br><b>Synthetic Type:</b> <a href='?_src_=prefs;preference=synth_type;task=input'>[synthetic_type]</a><br>"
+
+	dat += "<br><b>Synthetic name:</b> <a href='?_src_=prefs;preference=synth_name;task=input'>[synthetic_name]</a><br>"
+	dat += "<br><b>Synthetic Type:</b> <a href='?_src_=prefs;preference=synth_type;task=input'>[synthetic_type]</a><br>"
 
 	dat += "<div id='wrapper'>"
 	dat += "<big><big><b>Name:</b> "

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -471,7 +471,7 @@
 	name = "Synthetic"
 	name_plural = "synthetics"
 
-	unarmed_type = /datum/unarmed_attack/punch/strong
+	unarmed_type = /datum/unarmed_attack/punch
 	rarity_value = 2
 
 	total_health = 150 //more health than regular humans
@@ -489,7 +489,7 @@
 
 	body_temperature = 350
 
-	flags = IS_WHITELISTED|NO_BREATHE|NO_SCAN|NO_BLOOD|NO_POISON|NO_PAIN|IS_SYNTHETIC|NO_CHEM_METABOLIZATION
+	flags = NO_BREATHE|NO_SCAN|NO_BLOOD|NO_POISON|NO_PAIN|IS_SYNTHETIC|NO_CHEM_METABOLIZATION
 
 	blood_color = "#EEEEEE"
 
@@ -498,16 +498,13 @@
 		"brain" =    /datum/internal_organ/brain/prosthetic,
 		)
 
-	knock_down_reduction = 5
-	stun_reduction = 5
-
 
 /datum/species/early_synthetic
 	name = "Early Synthetic"
 	name_plural = "Early Synthetics"
 	icobase = 'icons/mob/human_races/r_synthetic.dmi'
 	deform = 'icons/mob/human_races/r_synthetic.dmi'
-	unarmed_type = /datum/unarmed_attack/punch/strong
+	unarmed_type = /datum/unarmed_attack/punch
 	rarity_value = 1.5
 	slowdown = 1.3 //Slower than later synths
 	total_health = 200 //But more durable
@@ -525,7 +522,7 @@
 
 	body_temperature = 350
 
-	flags = IS_WHITELISTED|NO_BREATHE|NO_SCAN|NO_BLOOD|NO_POISON|NO_PAIN|IS_SYNTHETIC|NO_CHEM_METABOLIZATION
+	flags = NO_BREATHE|NO_SCAN|NO_BLOOD|NO_POISON|NO_PAIN|IS_SYNTHETIC|NO_CHEM_METABOLIZATION
 
 	blood_color = "#EEEEEE"
 	hair_color = "#000000"
@@ -534,8 +531,6 @@
 		"brain" =    /datum/internal_organ/brain/prosthetic,
 		)
 
-	knock_down_reduction = 2
-	stun_reduction = 2
 
 /datum/species/zombie
 	name= "Zombie"


### PR DESCRIPTION
Порт https://github.com/ColonialMarines-Mirror/ColonialMarines-2018/pull/200
Синтам убраны сопротивление станам, навыки командования и ближнего боя. Ранним моделям синтов оставлен навык оружия ближнего боя.