### PR TITLE
Куча различных мелкофиксов

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -194,7 +194,7 @@
 /datum/skills/pilot
 	name = "Pilot Officer"
 	pilot = SKILL_PILOT_TRAINED
-	powerloader = SKILL_POWERLOADER_DABBLING
+	powerloader = SKILL_POWERLOADER_PRO
 	leadership = SKILL_LEAD_TRAINED
 
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -489,12 +489,9 @@
 	health = 1000000 //Failsafe, shouldn't matter
 
 /obj/structure/window/framed/almayer/requisitions
-	name = "ultra-reinforced window"
-	desc = "An ultra-reinforced window designed to keep requisitions a secure area."
-	not_damageable = 1
-	not_deconstructable = 1
-	unacidable = 1
-	health = 1000000 //Failsafe, shouldn't matter
+	name = "kevlar-weave infused bulletproof window"
+	desc = "A borosilicate glass window infused with kevlar fibres and mounted within a special shock-absorbing frame, this is gonna be seriously hard to break through."
+	health = 400
 	window_frame = /obj/structure/window_frame/almayer/requisitions
 
 /obj/structure/window/framed/almayer/white

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -14,10 +14,8 @@
 
 	var/permitted = 0
 	var/list/allowed = list("Syndicate","traitor","Wizard","Head Revolutionary","Cultist","Changeling")
-	for(var/T in allowed)
-		if(mind.special_role == T)
-			permitted = 1
-			break
+	if((mind.special_role in allowed) || ticker.current_state == GAME_STATE_FINISHED)
+		permitted = 1
 
 	if(!permitted)
 		message_admins("[ckey] has tried to suicide, but they were not permitted due to not being antagonist as human.", 1)

--- a/code/global.dm
+++ b/code/global.dm
@@ -219,6 +219,9 @@ var/list/APCWireColorToFlag = RandomAPCWires()
 var/list/APCIndexToFlag
 var/list/APCIndexToWireColor
 var/list/APCWireColorToIndex
+// Optimization for the APCS, this list contains every APC, faster to search through it then the old method was.
+var/list/apcs_list = list()
+// *******
 var/list/BorgWireColorToFlag = RandomBorgWires()
 var/list/BorgIndexToFlag
 var/list/BorgIndexToWireColor

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -139,7 +139,7 @@
 
 /obj/machinery/power/apc/New(turf/loc, var/ndir, var/building=0)
 	..()
-
+	apcs_list += src
 	//Offset 24 pixels in direction of dir
 	//This allows the APC to be embedded in a wall, yet still inside an area
 	if(building)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -279,11 +279,9 @@
 	return null
 
 /area/proc/get_apc()
-	for(var/area/RA in src.related)
-		var/obj/machinery/power/apc/FINDME = locate() in RA
-		if (FINDME)
-			return FINDME
-
+	for(var/obj/machinery/power/apc/A in apcs_list)
+		if(A.area == src)
+			return A
 
 //Determines how strong could be shock, deals damage to mob, uses power.
 //M is a mob who touched wire/whatever

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -795,11 +795,9 @@ and you're good to go.
 			return
 
 		if(!config.allow_synthetic_gun_use)
-			if(ishuman(user))
-				var/mob/living/carbon/human/H = user
-				if(istype(H.species , /datum/species/synthetic))
-					to_chat(user, "<span class='warning'>Your program does not allow you to use firearms.</span>")
-					return
+			if(isSynth(user))
+				to_chat(user, "<span class='warning'>Your program does not allow you to use firearms.</span>")
+				return
 
 		if(flags_gun_features & GUN_TRIGGER_SAFETY)
 			to_chat(user, "<span class='warning'>The safety is on!</span>")

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -421,9 +421,6 @@
 		explosion(sploded, 0, 5, 10, 0)
 		sleep(3)
 
-	for(var/obj/structure/window/framed/almayer/requisitions/R in structure_list)
-		R.shatter_window(1) // break the reqs windows
-
 	explosion(get_turf(HangarLowerElevator), 0, 3, 5, 0)
 	var/datum/shuttle/ferry/hangar/hangarelevator = shuttle_controller.shuttles["Hangar"]
 	hangarelevator.process_state = FORCE_CRASH


### PR DESCRIPTION
Порт [раз](https://github.com/ColonialMarines-Mirror/ColonialMarines-2018/pull/265), [два](https://github.com/ColonialMarines-Mirror/ColonialMarines-2018/pull/237), [три](https://github.com/ColonialMarines-Mirror/ColonialMarines-2018/pull/193), [четыре](https://github.com/ColonialMarines-Mirror/ColonialMarines-2018/pull/250) и [пять](https://github.com/ColonialMarines-Mirror/ColonialMarines-2018/pull/253)

- Фикс использования оружия у старых моделей синтов
- Небольшой рефактор АПЦ
- Окна в карго теперь можно сломать
- Суицид доступен по окончанию раунда
- Пилот теперь быстрее управляется с паверлоадером