### PR TITLE
Танкопереезжание Complete Edition

### DIFF
--- a/code/modules/vehicles/cm_armored.dm
+++ b/code/modules/vehicles/cm_armored.dm
@@ -453,12 +453,29 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 		for(var/obj/O in contents)
 			O.loc = T
 		cdel(LC)
-		/obj/structure/showcase
 	else if (istype(A, /obj/structure/showcase))
 		var/obj/structure/showcase/SW = A
 		SW.visible_message("<span class='danger'>[root] crushes [SW]!</span>")
 		new /obj/item/stack/sheet/metal(SW.loc, 2)
 		cdel(SW)
+	else if (istype(A, /obj/structure/inflatable) && !istype(A, /obj/structure/inflatable/door))
+		var/obj/structure/inflatable/IW = A
+		IW.visible_message("<span class='danger'>[root] crushes [IW]!</span>")
+		playsound(loc, 'sound/machines/hiss.ogg', 25, 1)
+		visible_message("[IW] rapidly deflates!")
+		flick("wall_popping", IW)
+		sleep(3)
+		new /obj/structure/inflatable/popped(IW.loc)
+		cdel(IW)
+	else if (istype(A, /obj/structure/inflatable/door))
+		var/obj/structure/inflatable/ID = A
+		ID.visible_message("<span class='danger'>[root] crushes [ID]!</span>")
+		playsound(loc, 'sound/machines/hiss.ogg', 25, 1)
+		visible_message("[ID] rapidly deflates!")
+		flick("wall_popping", ID)
+		sleep(3)
+		new /obj/structure/inflatable/popped/door(ID.loc)
+		cdel(ID)
 	else if (istype(A, /obj/structure/closet))
 		var/obj/structure/closet/crate/CL = A
 		CL.break_open()

--- a/code/modules/vehicles/cm_armored.dm
+++ b/code/modules/vehicles/cm_armored.dm
@@ -443,18 +443,146 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 		if(CP.exproof)
 			return
 		CP.visible_message("<span class='danger'>[root] crushes [CP]!</span>")
+		new /obj/item/stack/sheet/metal(CP.loc, 1)
 		cdel(CP)
 	else if (istype(A, /obj/structure/largecrate))
 		var/obj/structure/largecrate/LC = A
 		LC.visible_message("<span class='danger'>[root] crushes [LC]!</span>")
+		new /obj/item/stack/sheet/wood(LC.loc, 2)
+		var/turf/T = get_turf(LC)
+		for(var/obj/O in contents)
+			O.loc = T
 		cdel(LC)
+		/obj/structure/showcase
+	else if (istype(A, /obj/structure/showcase))
+		var/obj/structure/showcase/SW = A
+		SW.visible_message("<span class='danger'>[root] crushes [SW]!</span>")
+		new /obj/item/stack/sheet/metal(SW.loc, 2)
+		cdel(SW)
+	else if (istype(A, /obj/structure/closet))
+		var/obj/structure/closet/crate/CL = A
+		CL.break_open()
+		CL.open()
+		CL.visible_message("<span class='danger'>[root] crushes [CL]!</span>")
+		new /obj/item/stack/sheet/metal(CL.loc, 1)
+		cdel(CL)
+	else if (istype(A, /obj/machinery/marine_turret_frame))
+		var/obj/machinery/marine_turret_frame/MTF = A
+		MTF.visible_message("<span class='danger'>[root] crushes [MTF]!</span>")
+		new /obj/item/stack/sheet/plasteel(MTF.loc, 15)
+		if(MTF.has_cable)
+			new /obj/item/stack/cable_coil(MTF.loc, 10)
+		if(MTF.has_top)
+			new /obj/item/device/turret_top(MTF.loc)
+		if(MTF.has_sensor)
+			new /obj/item/device/turret_sensor(MTF.loc)
+		cdel(MTF)
+
+	else if (istype(A, /obj/machinery/marine_turret))
+		var/obj/machinery/marine_turret/MT = A
+		MT.visible_message("<span class='danger'>[root] drives over [MT]!</span>")
+		MT.stat = 1
+		MT.density = 0
+		MT.health = MT.health - 15
+		MT.update_icon()
+
+	else if (istype(A, /obj/machinery/m56d_post))
+		var/obj/machinery/m56d_post/MD = A
+		new /obj/item/device/m56d_post(MD.loc)
+		cdel(MD)
+
+	else if (istype(A, /obj/machinery/m56d_hmg) && !istype(A, /obj/machinery/m56d_hmg/mg_turret))
+		var/obj/machinery/m56d_hmg/MG = A
+		var/obj/item/device/m56d_gun/HMG = new(MG.loc) //Here we generate our disassembled mg.
+		new /obj/item/device/m56d_post(MG.loc)
+		HMG.rounds = MG.rounds //Inherent the amount of ammo we had.
+		cdel(MG)
+
+	else if (istype(A, /obj/structure/mortar))
+		var/obj/structure/mortar/MR = A
+		var/turf/T = get_turf(MR)
+		new /obj/item/mortar_kit(T)
+		cdel(MR)
+
 	else if(istype(A, /obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/AR = A
 		var/obj/vehicle/multitile/root/cm_armored/CA = root
 		CA.take_damage_type(30, "blunt", AR)
 		playsound(AR, 'sound/effects/metal_crash.ogg', 35)
+		AR.visible_message("<span class='danger'>[root] crushes through[AR]!</span>")
+		new /obj/item/stack/sheet/metal(AR.loc, 2)
 		cdel(AR)
 
+	else if(istype(A, /obj/machinery/door/poddoor/almayer))
+		var/obj/machinery/door/poddoor/almayer/PA = A
+		var/obj/vehicle/multitile/root/cm_armored/CA = root
+		CA.take_damage_type(40, "blunt", PA)
+		playsound(PA, 'sound/effects/metal_crash.ogg', 35)
+		PA.visible_message("<span class='danger'>[root] crushes through[PA]!</span>")
+		new /obj/item/stack/sheet/metal(PA.loc, 3)
+		cdel(PA)
+
+	else if(istype(A, /obj/machinery/door/poddoor/shutters) && !istype(A, /obj/machinery/door/poddoor/shutters/transit))
+		var/obj/machinery/door/poddoor/almayer/SH = A
+		var/obj/vehicle/multitile/root/cm_armored/CA = root
+		CA.take_damage_type(15, "blunt", SH)
+		playsound(SH, 'sound/effects/metal_crash.ogg', 35)
+		SH.visible_message("<span class='danger'>[root] crushes through[SH]!</span>")
+		cdel(SH)
+
+	else if (istype(A, /obj/structure/ship_ammo))
+		var/obj/structure/ship_ammo/SA = A
+		SA.visible_message("<span class='danger'>[root] crushes [SA]!</span>")
+		cdel(SA)
+
+	else if (istype(A, /obj/structure/dropship_equipment))
+		var/obj/structure/dropship_equipment/DE = A
+		DE.visible_message("<span class='danger'>[root] crushes [DE]!</span>")
+		cdel(DE)
+
+	else if (istype(A, /obj/machinery/microwave))
+		var/obj/machinery/microwave/MW = A
+		MW.visible_message("<span class='danger'>[root] crushes [MW]!</span>")
+		cdel(MW)
+
+	else if (istype(A, /obj/structure/ore_box))
+		var/obj/structure/ore_box/OB = A
+		OB.visible_message("<span class='danger'>[root] crushes [OB]!</span>")
+		cdel(OB)
+
+	else if (istype(A, /obj/structure/mopbucket))
+		var/obj/structure/mopbucket/MB = A
+		MB.visible_message("<span class='danger'>[root] crushes [MB]!</span>")
+		cdel(MB)
+
+	else if (istype(A, /obj/machinery/portable_atmospherics/hydroponics))
+		var/obj/machinery/portable_atmospherics/hydroponics/HY = A
+		new /obj/item/stack/sheet/metal(HY.loc, 1)
+		HY.visible_message("<span class='danger'>[root] crushes [HY]!</span>")
+		cdel(HY)
+
+	else if (istype(A, /obj/structure/door_assembly))
+		var/obj/structure/door_assembly/DA = A
+		new /obj/item/stack/sheet/metal(DA.loc, 2)
+		DA.visible_message("<span class='danger'>[root] crushes through[DA]!</span>")
+		cdel(DA)
+
+	else if (istype(A,/obj/structure/grille))
+		var/obj/structure/grille/GR = A
+		new /obj/item/stack/rods(GR.loc, 2)
+		GR.visible_message("<span class='danger'>[root] crushes through[GR]!</span>")
+		cdel(GR)
+
+	else if (istype(A, /obj/structure/foamedmetal))
+		var/obj/structure/foamedmetal/FM = A
+		FM.visible_message("<span class='danger'>[root] crushes through[FM]!</span>")
+		cdel(FM)
+
+	else if (istype(A, /obj/structure/device))
+		var/obj/structure/device/DV = A
+		new /obj/item/stack/sheet/wood(DV.loc, 1)
+		DV.visible_message("<span class='danger'>[root] crushes [DV]!</span>")
+		cdel(DV)
 
 /obj/vehicle/multitile/hitbox/cm_armored/Move(var/atom/A, var/direction)
 


### PR DESCRIPTION
Танк переезжает:
1. Все виды шкафчиков, крейтов, гардеробов, локеров.
2. Ore box
3. большие крейты, открываемые монтировкой
4. hydroponics trays
5. ведро из под швабры
6. Shutters и легкие подлоки
7. Showcases (наконец-то)
8. Sentry turret frame. (разваливается на составные части и возвращает 15 листов пласстали из 20.
9. Sentry. (получает урон и заваливается на землю).
10. M56D и тренога от него. (Выпадают на землю, M56D HMG из Аламо и WO - исключения, их переехать нельзя)
11. Мортира (выпадает на землю)
12. Модули ДСов и аммуницию к ним.
13. Микроволновки.
14. Grille.
15. Foamed metal.
16. Пианино всех видов.
17. Крупные вещи наносят урон, из многих объектов падает 1-2 листа металла, дерево или rods.