### PR TITLE
Restricting synth from MGs and Mortar

### DIFF
--- a/code/modules/cm_marines/equipment/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortars.dm
@@ -114,6 +114,9 @@
 		if(user.mind && user.mind.cm_skills && user.mind.cm_skills.engineer < SKILL_ENGINEER_ENGI)
 			to_chat(user, "<span class='warning'>You don't have the training to fire [src].</span>")
 			return
+		if(isSynth(user)
+			to_chat(user, "Your programming restricts operating heavy weaponry.")
+			return
 		if(busy)
 			to_chat(user, "<span class='warning'>Someone else is currently using [src].</span>")
 			return

--- a/code/modules/cm_marines/equipment/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortars.dm
@@ -114,7 +114,7 @@
 		if(user.mind && user.mind.cm_skills && user.mind.cm_skills.engineer < SKILL_ENGINEER_ENGI)
 			to_chat(user, "<span class='warning'>You don't have the training to fire [src].</span>")
 			return
-		if(isSynth(user)
+		if(isSynth(user))
 			to_chat(user, "Your programming restricts operating heavy weaponry.")
 			return
 		if(busy)

--- a/code/modules/cm_marines/equipment/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortars.dm
@@ -114,9 +114,10 @@
 		if(user.mind && user.mind.cm_skills && user.mind.cm_skills.engineer < SKILL_ENGINEER_ENGI)
 			to_chat(user, "<span class='warning'>You don't have the training to fire [src].</span>")
 			return
-		if(isSynth(user))
-			to_chat(user, "Your programming restricts operating heavy weaponry.")
-			return
+		if(!config.allow_synthetic_gun_use)
+			if(isSynth(user))
+				to_chat(user, "<span class='warning'>Your programming restricts operating heavy weaponry.</span>")
+				return
 		if(busy)
 			to_chat(user, "<span class='warning'>Someone else is currently using [src].</span>")
 			return

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -544,7 +544,7 @@
 			if(user.interactee) //Make sure we're not manning two guns at once, tentacle arms.
 				to_chat(user, "You're already manning something!")
 				return
-			if(isSynth(user)
+			if(isSynth(user))
 				to_chat(user, "Your programming restricts operating heavy weaponry.")
 				return
 			if(user.get_active_hand() != null)

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -544,9 +544,10 @@
 			if(user.interactee) //Make sure we're not manning two guns at once, tentacle arms.
 				to_chat(user, "You're already manning something!")
 				return
-			if(isSynth(user))
-				to_chat(user, "Your programming restricts operating heavy weaponry.")
-				return
+			if(!config.allow_synthetic_gun_use)
+				if(isSynth(user))
+					to_chat(user, "<span class='warning'>Your programming restricts operating heavy weaponry.</span>")
+					return
 			if(user.get_active_hand() != null)
 				to_chat(user, "<span class='warning'>You need a free hand to man the [src].</span>")
 			else

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -544,6 +544,9 @@
 			if(user.interactee) //Make sure we're not manning two guns at once, tentacle arms.
 				to_chat(user, "You're already manning something!")
 				return
+			if(isSynth(user)
+				to_chat(user, "Your programming restricts operating heavy weaponry.")
+				return
 			if(user.get_active_hand() != null)
 				to_chat(user, "<span class='warning'>You need a free hand to man the [src].</span>")
 			else

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -98,6 +98,15 @@ should be listed in the changelog upon commit though. Thanks. -->
 
 
 <div class='commit sansserif'>
+	<h2 class='date'>November 11 2018</h2>
+	<h3 class='author'>jeser updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='bugfix'>Removed ability to use M56D and mortars from synths. | Убрал возможность использовать M56D и миномет за синтетика.</li>
+	</ul>
+</div>
+
+
+<div class='commit sansserif'>
 	<h2 class='date'>November 10 2018</h2>
 	<h3 class='author'>Polion1232 updated:</h3>
 	<ul class='changes bgimages16'>


### PR DESCRIPTION
Disallows synthetics from using M56D and Mortar, unless synths were allowed to use firearms.