### PR TITLE
Боты против Танка

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/aliens/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/aliens/alien.dm
@@ -39,7 +39,7 @@
 	var/attack_same = 0
 	var/list/friends = list()
 	var/stance = HOSTILE_STANCE_IDLE
-	var/mob/living/target_mob
+	var/atom/target = null
 	var/mob/living/leader
 	var/destroy_surroundings = 1
 	var/move_to_delay = 3
@@ -113,6 +113,9 @@
 	melee_damage_upper = 45
 	maxHealth = 400
 	health = 400
+
+	pixel_x = -16
+	old_x = -16
 
 	var/rage = 0								//The more you hit with bullets, meanier it would be
 	var/maxrage = 3

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -343,6 +343,8 @@
 		var/mob/living/L = target_mob
 		if(!L.stat)
 			return (0)
+	if(isMech(target_mob) || isTank(target_mob))
+		return (0)
 	if (istype(target_mob,/obj/mecha))
 		var/obj/mecha/M = target_mob
 		if (M.occupant)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -216,6 +216,24 @@ proc/isSynth(A)
 			return 1
 	return 0
 
+proc/isVehicle(A)
+	if(istype(A, /obj/vehicle))
+		return 1
+	else
+		return 0
+
+proc/isMech(A)
+	if(istype(A, /obj/vehicle/walker))
+		return 1
+	else
+		return 0
+
+proc/isTank(A)
+	if(istype(A, /obj/vehicle/multitile/hitbox/cm_armored))
+		return 1
+	else
+		return 0
+
 proc/ismaintdrone(A)
 	if(istype(A,/mob/living/silicon/robot/drone))
 		return 1

--- a/code/modules/vehicles/cm_armored.dm
+++ b/code/modules/vehicles/cm_armored.dm
@@ -585,6 +585,7 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 		else remove_person = 0 //if something exists but isnt broken
 
 	if(remove_person)
+		health = 0					//broken anyway
 		handle_all_modules_broken()
 
 	update_icon()
@@ -1148,6 +1149,9 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 /obj/vehicle/multitile/hitbox/cm_armored/attack_alien(var/mob/living/carbon/Xenomorph/M, var/dam_bonus)
 	return root.attack_alien(M, dam_bonus)
 
+/obj/vehicle/multitile/hitbox/cm_armored/attack_animal(var/mob/living/simple_animal/M as mob)
+	return root.attack_animal(M)
+
 /obj/vehicle/multitile/hitbox/cm_armored/hear_talk(mob/M, text, verb, var/datum/language/speaking = null, italics=0)
 	return root.hear_talk(M, text, verb, null, italics)
 
@@ -1246,6 +1250,9 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 
 //Honestly copies some code from the Xeno files, just handling some special cases
 /obj/vehicle/multitile/root/cm_armored/attack_alien(var/mob/living/carbon/Xenomorph/M, var/dam_bonus)
+	if(health == 0)
+		to_chat(M, "You staring at [src.name] wreckage.")
+		return
 
 	var/damage = rand(M.melee_damage_lower, M.melee_damage_upper) + dam_bonus
 
@@ -1267,6 +1274,24 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 	"<span class='danger'>You slash [src]!</span>")
 
 	take_damage_type(damage * ( (M.caste == "Ravager") ? 2 : 1 ), "slash", M) //Ravs do a bitchin double damage
+
+	healthcheck()
+
+/obj/vehicle/multitile/root/cm_armored/attack_animal(var/mob/living/simple_animal/M as mob)
+	var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
+	if(!damage)
+		playsound(M.loc, 'sound/weapons/alien_claw_swipe.ogg', 25, 1)
+		M.animation_attack_on(src)
+		M.visible_message("<span class='danger'>\The [M] lunges at [src]!</span>", \
+		"<span class='danger'>You lunge at [src]!</span>")
+		return 0
+
+	M.animation_attack_on(src)
+	playsound(M.loc, pick('sound/weapons/alien_claw_metal1.ogg', 'sound/weapons/alien_claw_metal2.ogg', 'sound/weapons/alien_claw_metal3.ogg'), 25, 1)
+	M.visible_message("<span class='danger'>\The [M] slashes [src]!</span>", \
+	"<span class='danger'>You slash [src]!</span>")
+
+	take_damage_type(damage, "slash", M)
 
 	healthcheck()
 

--- a/code/modules/vehicles/walker/walker.dm
+++ b/code/modules/vehicles/walker/walker.dm
@@ -563,6 +563,13 @@
 		playsound(loc, 'sound/effects/metal_crash.ogg', 75)
 		cdel(src)
 
+/obj/vehicle/walker/attack_animal(mob/living/M)
+	M.animation_attack_on(src)
+	playsound(loc, "alien_claw_metal", 25, 1)
+	M.flick_attack_overlay(src, "slash")
+	visible_message("<span class='danger'>[M] slashes [src].</span>")
+	take_damage(rand(M.melee_damage_lower, M.melee_damage_upper), "slash")
+
 /obj/vehicle/walker/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)
 		return


### PR DESCRIPTION
- Ботоксены теперь атакуют танк и меху
- Танк и меха для ботоксен имеют меньший приоритет, чем обычные морпехи
- Ксеноморфы теперь не могут бить уже сломанный танк