### PR TITLE
Нерф автопушки

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -935,8 +935,8 @@
 		accuracy_var_low = config.med_proj_variance
 		accurate_range = config.short_shell_range
 		max_range = config.max_shell_range
-		damage = config.ultra_hit_damage
-		penetration= config.max_armor_penetration
+		damage = config.med_hit_damage
+		penetration = config.max_armor_penetration
 
 /datum/ammo/rocket/tow/on_hit_mob(mob/M, obj/item/projectile/P)
 		explosion(get_turf(M), 1, 1, 2, 5)

--- a/code/modules/projectiles/updated_projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/flamer.dm
@@ -206,10 +206,10 @@
 		if (S.slayer > 0)
 			S.slayer -= 1
 			S.update_icon(1, 0)
-	
+
 	for(var/obj/structure/jungle/vines/V in T)
 		cdel(V)
-		
+
 	for(var/mob/living/M in T) //Deal bonus damage if someone's caught directly in initial stream
 		if(M.stat == DEAD)
 			continue
@@ -382,11 +382,6 @@
 	if(burn_lvl)
 		burnlevel = burn_lvl
 	processing_objects.Add(src)
-
-	for(var/mob/living/L in loc)
-		if(L.on_fire)
-			continue
-		Crossed(L)
 
 	if(fire_spread_amount > 0)
 		var/turf/T

--- a/code/modules/vehicles/cm_armored.dm
+++ b/code/modules/vehicles/cm_armored.dm
@@ -649,6 +649,9 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 	var/obj/vehicle/multitile/root/cm_armored/CA = root
 	if(isliving(A))
 		var/mob/living/M = A
+		if(isXenoBot(M))
+			var/mob/living/simple_animal/alien/XB = M
+			XB.adjustBruteLoss(25)
 		if(isXeno(M))
 			var/mob/living/carbon/Xenomorph/XEN = M
 			switch(CA.vehicle_class)
@@ -716,7 +719,7 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 							step_away(M,root,0)
 							//M.visible_message("<span class='danger'>[M] pushes against the [src], trying to hold it in place, but fails!</span>", "<span class='danger'>[src] is much heavier, you can't hold it in place!</span>")
 							return
-		if (!isXeno(M))
+		if (!isXeno(M) && !isXenoBot(M))
 			if(M.buckled)
 				M.buckled.unbuckle()
 			step_away(M,root,0,0)

--- a/code/modules/vehicles/hardpoints.dm
+++ b/code/modules/vehicles/hardpoints.dm
@@ -232,8 +232,8 @@ All of the hardpoints, for the tank and APC
 	max_angle = 60
 
 	apply_buff()
-		owner.cooldowns["primary"] = 2.5
-		owner.accuracies["primary"] = 0.97
+		owner.cooldowns["primary"] = 5
+		owner.accuracies["primary"] = 0.77
 	is_ready()
 		if(world.time < next_use)
 			to_chat(usr, "<span class='warning'>This module is not ready to be used yet.</span>")

--- a/code/modules/vehicles/hardpoints.dm
+++ b/code/modules/vehicles/hardpoints.dm
@@ -233,7 +233,7 @@ All of the hardpoints, for the tank and APC
 
 	apply_buff()
 		owner.cooldowns["primary"] = 5
-		owner.accuracies["primary"] = 0.77
+		owner.accuracies["primary"] = 0.9
 	is_ready()
 		if(world.time < next_use)
 			to_chat(usr, "<span class='warning'>This module is not ready to be used yet.</span>")


### PR DESCRIPTION
- Понижена скорость атаки автопушки
- Слегка понижена точность автопушки
- TOW танка теперь наносит вдвое меньше урона. Раньше был урон в 150 против урона снаряда ЛТБ в 70
- Ботоксен теперь можно раздавить танком.
- Откат попытки зафиксить огонь. Он вызвал другой баг, а старый оставил