### PR TITLE
мини-набор

### DIFF
--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -344,7 +344,8 @@
 //Decides whether or not to damage a player's eyes based on what they're wearing as protection
 //Note: This should probably be moved to mob
 /obj/item/tool/weldingtool/proc/eyecheck(mob/user)
-	if(!iscarbon(user))	return 1
+	return
+/*	if(!iscarbon(user))	return 1
 	var/safety = user.get_eye_protection()
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -383,7 +384,7 @@
 				H.disabilities |= NEARSIGHTED
 				spawn(100)
 					H.disabilities &= ~NEARSIGHTED
-
+*/
 
 
 

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Defender/Defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Defender/Defender.dm
@@ -33,9 +33,6 @@
 		/datum/action/xeno_action/activable/headbutt,
 		/datum/action/xeno_action/activable/tail_sweep
 		)
-	inherent_verbs = list(
-		/mob/living/carbon/Xenomorph/proc/vent_crawl,
-		)
 
 /mob/living/carbon/Xenomorph/Defender/update_icons()
 	if (stat == DEAD)

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Queen/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Queen/Queen.dm
@@ -394,7 +394,7 @@
 		to_chat(src, "<span class='warning'>You are not ready to screech again.</span>")
 		return
 
-	if(!check_plasma(250))
+	if(!check_plasma(plasma_max))
 		return
 
 	//screech is so powerful it kills huggers in our hands
@@ -409,8 +409,8 @@
 			FH.Die()
 
 	has_screeched = 1
-	use_plasma(250)
-	spawn(500)
+	use_plasma(plasma_max)
+	spawn(1000)
 		has_screeched = 0
 		to_chat(src, "<span class='warning'>You feel your throat muscles vibrate. You are ready to screech again.</span>")
 		for(var/Z in actions)

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Warrior/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Warrior/Warrior.dm
@@ -32,9 +32,6 @@
 		/datum/action/xeno_action/activable/lunge,
 		/datum/action/xeno_action/activable/punch
 		)
-	inherent_verbs = list(
-		/mob/living/carbon/Xenomorph/proc/vent_crawl,
-		)
 
 /mob/living/carbon/Xenomorph/Warrior/update_icons()
 	if (stat == DEAD)


### PR DESCRIPTION
- варриор и дефендер больше не влезают в венты
- нерф скрича квины: теперь он тратит всю плазму, а кулдаун в два раза больше. Если, в дополнение, запретить королевам смотреть аниме и кемпить в пещерах - сервер заживет.
- Горелки не портят зрение. Ибо у нас вселенная чужого, где все горелки с защитным экраном (так они еще и на спрайтах нарисованы)