### PR TITLE
Фиксы L42A

### DIFF
--- a/code/WorkInProgress/doctor_alex/weapons.dm
+++ b/code/WorkInProgress/doctor_alex/weapons.dm
@@ -405,3 +405,48 @@
 /datum/ammo/bullet/rifle/ak/incendiary/New()
 	..()
 	accurate_range = config.short_shell_range
+
+//--------------------------------------------ATTACHES--------------------------------------//
+
+/obj/item/attachable/stock/rifle/ak4047
+	name = "AK-4047 stock"
+	desc = "A rare stock distributed in small numbers to UPP forces. Compatible with the AK-4047, this stock reduces recoil and improves accuracy, but at a reduction to handling and agility. Seemingly a bit more effective in a brawl"
+	icon_state = "akstock"
+	attach_icon = "akstock_a"
+	pixel_shift_x = 45
+	pixel_shift_y = 13
+
+/obj/item/attachable/flashlight/ak
+	name = "AK flashlight"
+	desc = "A simple flashlight used for mounting on a firearm. \nHas no drawbacks, but isn't particuraly useful outside of providing a light source."
+	icon_state = "akflashlight"
+	attach_icon = "akflashlight_a"
+	light_mod = 7
+	pixel_shift_x = 24
+	pixel_shift_y = 12
+	slot = "muzzle"
+	matter = list("metal" = 50,"glass" = 20)
+	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION
+	attachment_action_type = /datum/action/item_action/toggle
+
+/obj/item/attachable/flashlight/ak/activate_attachment(obj/item/weapon/gun/G, mob/living/user, turn_off)
+	if(turn_off && !(G.flags_gun_features & GUN_FLASHLIGHT_ON))
+		return
+	var/flashlight_on = (G.flags_gun_features & GUN_FLASHLIGHT_ON) ? -1 : 1
+	var/atom/movable/light_source =  ismob(G.loc) ? G.loc : G
+	light_source.SetLuminosity(light_mod * flashlight_on)
+	G.flags_gun_features ^= GUN_FLASHLIGHT_ON
+
+	if(G.flags_gun_features & GUN_FLASHLIGHT_ON)
+		icon_state = "akflashlight-on"
+		attach_icon = "akflashlight_a-on"
+	else
+		icon_state = "akflashlight"
+		attach_icon = "akflashlight_a"
+
+	G.update_attachable(slot)
+
+	for(var/X in G.actions)
+		var/datum/action/A = X
+		A.update_button_icon()
+	return TRUE

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -307,6 +307,24 @@ WEAPONS
 	containername = "rifles crate"
 	group = "Weapons"
 
+/datum/supply_packs/gun/l42a
+	contains = list(
+					/obj/item/ammo_magazine/l42a/ap,
+					/obj/item/ammo_magazine/l42a/ap,
+					/obj/item/ammo_magazine/l42a/ap,
+					/obj/item/ammo_magazine/l42a/ap,
+					/obj/item/ammo_magazine/l42a/ap,
+					/obj/item/ammo_magazine/l42a/ap,
+					/obj/item/ammo_magazine/l42a/incendiary,
+					/obj/item/ammo_magazine/l42a/incendiary,
+					/obj/item/ammo_magazine/l42a/incendiary
+					)
+	name = "surplus sniper crate (L42A AP mags x6, L42A incendiary ammo x3)"
+	cost = RO_PRICE_PRICY
+	containertype = /obj/structure/closet/crate
+	containername = "sniper crate"
+	group = "Weapons"
+
 /datum/supply_packs/gun/heavyrifle
 	contains = list(
 					/obj/item/weapon/gun/rifle/lmg,

--- a/code/game/machinery/vending/marine_vending.dm
+++ b/code/game/machinery/vending/marine_vending.dm
@@ -196,6 +196,7 @@
 					/obj/item/ammobox/m39ext = 1,
 					/obj/item/ammo_magazine/smg/m39/extended = 5,
 					/obj/item/ammobox = 3,
+					/obj/item/ammo_magazine/l42a = 15,
 					/obj/item/ammo_magazine/rifle = 15,
 					/obj/item/ammobox/ext = 1,
 					/obj/item/ammo_magazine/rifle/extended = 5,

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -271,6 +271,7 @@
 		"/obj/item/ammo_magazine/sniper",
 		"/obj/item/ammo_magazine/handful",
 		"/obj/item/flareround_s",
+		"/obj/item/ammo_magazine/l42a",
 		"/obj/item/flareround_sp",
 		"/obj/item/explosive/grenade",
 		"/obj/item/explosive/mine",

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -428,9 +428,6 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 		A.update_button_icon()
 	return TRUE
 
-
-
-
 /obj/item/attachable/flashlight/attackby(obj/item/I, mob/user)
 	if(istype(I,/obj/item/tool/screwdriver))
 		to_chat(user, "<span class='notice'>You modify the rail flashlight back into a normal flashlight.</span>")
@@ -444,41 +441,6 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 		cdel(src) //Delete da old flashlight
 	else
 		return ..()
-
-/obj/item/attachable/flashlight/ak
-	name = "AK flashlight"
-	desc = "A simple flashlight used for mounting on a firearm. \nHas no drawbacks, but isn't particuraly useful outside of providing a light source."
-	icon_state = "akflashlight"
-	attach_icon = "akflashlight_a"
-	light_mod = 7
-	pixel_shift_x = 24
-	pixel_shift_y = 12
-	slot = "muzzle"
-	matter = list("metal" = 50,"glass" = 20)
-	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION
-	attachment_action_type = /datum/action/item_action/toggle
-
-/obj/item/attachable/flashlight/ak/activate_attachment(obj/item/weapon/gun/G, mob/living/user, turn_off)
-	if(turn_off && !(G.flags_gun_features & GUN_FLASHLIGHT_ON))
-		return
-	var/flashlight_on = (G.flags_gun_features & GUN_FLASHLIGHT_ON) ? -1 : 1
-	var/atom/movable/light_source =  ismob(G.loc) ? G.loc : G
-	light_source.SetLuminosity(light_mod * flashlight_on)
-	G.flags_gun_features ^= GUN_FLASHLIGHT_ON
-
-	if(G.flags_gun_features & GUN_FLASHLIGHT_ON)
-		icon_state = "akflashlight-on"
-		attach_icon = "akflashlight_a-on"
-	else
-		icon_state = "akflashlight"
-		attach_icon = "akflashlight_a"
-
-	G.update_attachable(slot)
-
-	for(var/X in G.actions)
-		var/datum/action/A = X
-		A.update_button_icon()
-	return TRUE
 
 /obj/item/attachable/quickfire
 	name = "quickfire adapter"
@@ -640,14 +602,6 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	recoil_mod = -config.med_recoil_value
 	scatter_mod = -config.med_scatter_value
 	movement_acc_penalty_mod = config.min_movement_acc_penalty
-
-/obj/item/attachable/stock/rifle/ak4047
-	name = "AK-4047 stock"
-	desc = "A rare stock distributed in small numbers to UPP forces. Compatible with the AK-4047, this stock reduces recoil and improves accuracy, but at a reduction to handling and agility. Seemingly a bit more effective in a brawl"
-	icon_state = "akstock"
-	attach_icon = "akstock_a"
-	pixel_shift_x = 45
-	pixel_shift_y = 13
 
 /obj/item/attachable/stock/rifle/marksman
 	name = "M41A marksman stock"


### PR DESCRIPTION
- rscadd: Добавил в карго-вендор 15 обычных магазинов L42A
- rscadd: Зажигательные и АПшные патроны к L42A можно заказать в карго
- bugfix: Магазины от эльки теперь можно класть в аммо-белт. Насчёт поучей неуверен.